### PR TITLE
executing the docker container prints IP-address

### DIFF
--- a/docker-serve-test.sh
+++ b/docker-serve-test.sh
@@ -2,4 +2,6 @@
 sed 's/\/\/\//\/\/postgres@postgres\//' muesli.yml.example | sed 's/localhost/0.0.0.0/' > muesli.yml
 sed 's/\/\/\//\/\/postgres@postgres\//' alembic.ini.example > alembic.ini
 python3 -m smtpd -n -c DebuggingServer localhost:25 &
+echo -n "IP-address: "
+ip -4 addr show | grep -oP "(?<=inet ).*(?=/)" | grep -ve "127.0.0.1"
 su -c /opt/muesli4/muesli-test muesli


### PR DESCRIPTION
This is usefull, if the port is blocked/in use, since one can use the
IP-Address directly (at least on linux-systems).

Ist für mich nötig, damit ich auf den Container zugreifen kann. Beispiel Output:

> Starting muesli_postgres_1 ... done
> IP-address: 172.19.0.3
> serving on 0.0.0.0:8080 view at http://127.0.0.1:8080
